### PR TITLE
libudev and alsaLib were renamed on NixOS

### DIFF
--- a/client/src/nix.rs
+++ b/client/src/nix.rs
@@ -6,7 +6,7 @@ const PATCH_DRV: &str = r#"
 let
   runtimeLibs =
     with pkgs;
-    ([ libGL libxkbcommon libudev alsaLib vulkan-loader vulkan-extension-layer stdenv.cc.cc.lib ]
+    ([ libGL libxkbcommon udev alsa-lib vulkan-loader vulkan-extension-layer stdenv.cc.cc.lib ]
             ++ (with xorg; [ libxcb libX11 libXcursor libXrandr libXi ]));
 in
 pkgs.stdenv.mkDerivation {


### PR DESCRIPTION
We recently started throwing errors for old, deprecated aliases on NixOS which caused airshipper to fail patching things.

libudev is now udev and alsaLib is alsa-lib
